### PR TITLE
Fix required tag updates for policy tag lists

### DIFF
--- a/src/libs/actions/Policy/Tag.ts
+++ b/src/libs/actions/Policy/Tag.ts
@@ -998,15 +998,19 @@ function setPolicyRequiresTag(policyData: PolicyData, requiresTag: boolean) {
         ],
     };
 
-    const getUpdatedTagsData = (required: boolean): PolicyTagLists => ({
-        ...Object.keys(policyData.tags).reduce<PolicyTagLists>((acc, key) => {
+    const getUpdatedTagsData = (required: boolean): PolicyTagLists =>
+        Object.keys(policyData.tags ?? {}).reduce<PolicyTagLists>((acc, key) => {
+            const tagList = policyData.tags?.[key];
+            if (!tagList) {
+                return acc;
+            }
+
             acc[key] = {
-                ...acc[key],
+                ...tagList,
                 required,
             };
             return acc;
-        }, {}),
-    });
+        }, {});
 
     const getUpdatedTagsOnyxData = (required: boolean): OnyxUpdate => ({
         key: `${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`,


### PR DESCRIPTION
### Motivation
- Fix failures when toggling the policy `requiresTag` flag that occurred due to attempting to spread or merge undefined tag list entries when building updated policy tag data.

### Description
- Changed `getUpdatedTagsData` in `src/libs/actions/Policy/Tag.ts` to iterate over `policyData.tags ?? {}` and guard against missing tag lists by skipping undefined entries and merging from the actual `tagList` instead of spreading possibly-undefined accumulator entries.

### Testing
- Attempted to run `npm test -- --runTestsByPath tests/actions/PolicyTagTest.ts`, but `jest` was not available in the environment so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f877ed90832d88e9f3386c7050b3)